### PR TITLE
custom repo-getter object completed with api/repo?url=xxx endpoint

### DIFF
--- a/client/components/FileTree.js
+++ b/client/components/FileTree.js
@@ -1,7 +1,6 @@
 //FileTree.js
 import React from 'react';
 import { Link } from 'react-router';
-import buildRepoObject from '../utilities/buildRepoObject';
 
 const FileTree = React.createClass({
 
@@ -44,7 +43,7 @@ const FileTree = React.createClass({
     .then(response => {
       return response.json()})
     .then(fileContent => {
-      console.log(fileContent);
+      //console.log(fileContent);
       this.props.receiveFileContent(atob(fileContent.content));
     });
   },

--- a/client/components/FileTree.js
+++ b/client/components/FileTree.js
@@ -1,6 +1,7 @@
 //FileTree.js
 import React from 'react';
 import { Link } from 'react-router';
+import buildRepoObject from '../utilities/buildRepoObject';
 
 const FileTree = React.createClass({
 
@@ -21,14 +22,16 @@ const FileTree = React.createClass({
   logRepo(e) {
     e.preventDefault();
     const repo = e.target.value;
+    const baseUrl = 'https://api.github.com/repos/'+this.props.username+'/'+repo+'/contents';
     this.props.requestRepoContents(repo);
 
-    fetch('https://api.github.com/repos/'+this.props.username+'/'+repo+'/contents')
+    fetch(baseUrl)
     .then(response => {
       return response.json()})
     .then(repoContents => {
-      console.log(repoContents);
+      //console.log(repoContents);
       this.props.receiveRepoContents(repoContents);
+
     });
   },
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "esprima": "^3.0.0",
     "estraverse": "^4.2.0",
     "express": "^4.14.0",
+    "filewalker": "^0.1.3",
     "fs": "0.0.1-security",
+    "nodegit": "^0.16.0",
     "react": "^15.3.2",
     "react-bootstrap": "^0.30.3",
     "react-codemirror": "^0.2.6",
@@ -35,6 +37,7 @@
     "redbox-react": "^1.2.3",
     "redux": "^3.6.0",
     "redux-promise": "^0.5.3",
+    "rimraf": "^2.5.4",
     "webpack": "^1.13.2",
     "webpack-dev-middleware": "^1.8.3",
     "webpack-hot-middleware": "^2.12.2"

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ var path = require('path');
 var express = require('express');
 var webpack = require('webpack');
 var config = require('./webpack.config.dev');
+var buildRepoObject = require('./server/buildRepoObject');
 
 var app = express();
 var compiler = webpack(config);
@@ -12,6 +13,13 @@ app.use(require('webpack-dev-middleware')(compiler, {
 }));
 
 app.use(require('webpack-hot-middleware')(compiler));
+
+app.get('/api/repo', (req, res, next)=>{
+  buildRepoObject(req.query.url, (data)=> {
+    //the data should be passed to the parser here
+    res.json(data);
+  })
+})
 
 app.get('*', function(req, res) {
   res.sendFile(path.join(__dirname, 'index.html'));

--- a/server/buildRepoObject.js
+++ b/server/buildRepoObject.js
@@ -3,7 +3,6 @@ const Git = require("nodegit");
 const rmrf = require("rimraf");
 const filewalker = require('filewalker');
 
-
 function buildRepoObject(directory, cb){
 
   let finalObj, repoObj = {};
@@ -32,12 +31,3 @@ function buildRepoObject(directory, cb){
 }
 
 module.exports = buildRepoObject;
-
-/*let myData;
-
-buildRepoObject('https://github.com/kphurley/league-manager.git', function(data){
-  myData = data;
-
-});*/
-
-

--- a/server/buildRepoObject.js
+++ b/server/buildRepoObject.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const Git = require("nodegit");
+const rmrf = require("rimraf");
+const filewalker = require('filewalker');
+
+
+function buildRepoObject(directory, cb){
+
+  let finalObj, repoObj = {};
+
+  Git.Clone(directory, "./temp")
+  .then(function(repository) {
+
+    filewalker('./temp')
+    .on('file', function(path, s) {
+      if(path.substr(path.length-3) === '.js'){
+        repoObj[path] = fs.readFileSync('./temp/'+ path, 'utf-8');
+      }
+    })
+    .on('error', function(err) {
+      console.error(err);
+    })
+    .on('done', function() {
+      cb(repoObj);
+      rmrf("./temp", {}, function(err){
+        console.log(err);
+      });
+    })
+    .walk();
+
+  });
+}
+
+module.exports = buildRepoObject;
+
+/*let myData;
+
+buildRepoObject('https://github.com/kphurley/league-manager.git', function(data){
+  myData = data;
+
+});*/
+
+


### PR DESCRIPTION
I wrote a helper function that takes a github url ('github.com/<username>/<yourRepo>.git), temporarily clones that repo to the server, and organizes its JS code into an object that looks like this:

`{'somePath': ...file contents, 'someOtherPath': ...otherFileContents}...`

We will use this object for parsing, as well as reorganizing the file tree component.
