### PR TITLE
Done with setting up info box for hovered over node

### DIFF
--- a/client/components/DefinitionNode.js
+++ b/client/components/DefinitionNode.js
@@ -40,6 +40,11 @@ class DefinitionNode extends PaperNode {
     this.group.onMouseEnter = function(event){
       toggleHover(thisNode.nodeId)
     }
+
+    this.group.onMouseLeave = function(event){
+      console.log('we are done hovering', this.nodeId)
+      toggleHover(0)
+    }
   }
 
   colorAsActive(){

--- a/client/components/FunctionWeb.js
+++ b/client/components/FunctionWeb.js
@@ -11,6 +11,12 @@ const FunctionTree = React.createClass({
       window.document.getElementById('paper-container').className='fadeinpanel';
       // window.document.getElementById('paper-container').style.visibility='visible';
     }
+
+    if(this.showHover()){
+      let hoverOnlyBox = window.document.getElementById('hover-only-box')
+    }
+
+    console.log('heres showHover, ', this.showHover())
   },
 
   componentDidMount: function(){

--- a/client/components/HoverOver.js
+++ b/client/components/HoverOver.js
@@ -12,12 +12,23 @@ const HoverOver = React.createClass({
     let hoverOverStyle = {
           backgroundColor: "#7ec0ee",
           // need to figure out how to make it 100% (percentage instead of pixels)
-          width: 100,
-          height: 100
+          width: 700,
+          height: 80
     };
+    let hoveredOverNode = this.props.nodes[this.props.hoveredOverNodeId-1]
+    let funcName = hoveredOverNode.name,
+        funcType = hoveredOverNode.type,
+        funcFilePath = hoveredOverNode.filePath,
+        funcNumbIncNodes = hoveredOverNode.incomingEdges.length,
+        funcNumbOutNodes = hoveredOverNode.outgoingEdges.length;
 
     return(
-        <div style={hoverOverStyle}> Hovered Over Node showed up </div>
+        <div id="hover-only-box" style={hoverOverStyle}>
+            <div> Func Name {funcName} </div>
+            <div> File Path {funcFilePath} </div>
+           <div> Numb incoming Edges {funcNumbIncNodes} </div>
+           <div> Numb outgoing Edges {funcNumbOutNodes} </div>
+        </div>
 
     )
   }

--- a/client/components/InvocationNode.js
+++ b/client/components/InvocationNode.js
@@ -46,6 +46,11 @@ class InvocationNode extends PaperNode {
     this.group.onMouseEnter = function(event){
       toggleHover(thisNode.nodeId)
     }
+
+    this.group.onMouseLeave = function(event){
+    console.log('we are done hovering', this.nodeId)
+    toggleHover(0)
+    }
   }
 
   colorAsActive(){


### PR DESCRIPTION
An info box pops up on the bottom of the graph that displays information about the hovered over node.
