### PR TITLE
file-tree click bug resolved

### DIFF
--- a/client/utilities/TreeView.js
+++ b/client/utilities/TreeView.js
@@ -298,6 +298,7 @@ export class TreeNode extends React.Component {
     this.newNodeForm = this.newNodeForm.bind(this);
     this.addNode = this.addNode.bind(this);
     this.removeNode = this.removeNode.bind(this);
+    this.performNodeAction = this.performNodeAction.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -324,6 +325,13 @@ export class TreeNode extends React.Component {
   doubleClicked(event) {
     let selected = !this.props.node.state.selected;
     this.props.onNodeDoubleClicked(this.state.node.nodeId, selected);
+    event.stopPropagation();
+  }
+
+  performNodeAction(event) {
+    //if there are children nodes, expand the node.
+    //else - invoke double click, which should open the file
+    this.state.node.nodes ? this.toggleExpanded(event) : this.doubleClicked(event);
     event.stopPropagation();
   }
 
@@ -427,7 +435,9 @@ export class TreeNode extends React.Component {
     }
     else {
       nodeText = (
-          <span style={treeviewSpanStyle}> {node.text} </span>
+          <span style={treeviewSpanStyle}
+          onClick={this.performNodeAction}>
+          {node.text} </span>
       )
     }
 


### PR DESCRIPTION
I was able to modify TreeView.js slightly to allow for single-clicks to behave in a reasonable way.  Upon single-clicking a file, it will render the file.  If the node represents a folder, it will open the folder instead.  High-five!
