### PR TITLE
Fixed issue when you toggled a secondary node after a refresh it woul…

### DIFF
--- a/client/components/FunctionWeb.js
+++ b/client/components/FunctionWeb.js
@@ -46,7 +46,10 @@ const FunctionTree = React.createClass({
       let groups = activeLayer.children.filter(child => child.constructor === paper.Group)
       groups.forEach(group =>
           {
-            if(group.nodeId !== newHighlightedNodeId && group.nodeId !== this.props.activeNodeId){
+            let activeNodeId = this.props.activeNodeId;
+            let activeNodeIdNumb = +activeNodeId;
+
+            if(group.nodeId !== newHighlightedNodeId && group.nodeId !== activeNodeIdNumb){
               group.children[0].shadowBlur = 0;
               group.children[0].fillColor = '#b6d2dd';
               group.children[0].strokeColor = '#b6d2dd';

--- a/client/components/example.html
+++ b/client/components/example.html
@@ -14,7 +14,6 @@
 
         //attaching double click event handler
 path.onDoubleClick = function(event) {
-    console.log('hey there');
 }
 
 </script>


### PR DESCRIPTION
…d repaint the activeNode

The issue was that the activeNodeId was a string.
